### PR TITLE
add ignorecache generator on pageload

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1056,6 +1056,14 @@ for (var j = 0; j < dropDown.options.length; j++) {
   }
 }
 
+window.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll("section, figure").forEach((node) => {
+    if(node.dataset.source) {
+      node.dataset.source += `?ignoreCache=${Math.ceil(Math.random()*100)}`
+    }
+  })
+})
+
 
 
 })(this);


### PR DESCRIPTION
Adds `?ignoreCache={random number}` to all blocks to get around GCS caching 