### PR TITLE
add 30 days visualization and text

### DIFF
--- a/_includes/charts.html
+++ b/_includes/charts.html
@@ -19,25 +19,25 @@ plural = "" %} {% assign the = "the " %} {% endif %}
       -->
 <div id="main_data" class="width-two-thirds">
   <section
-    id="visitors-today"
-    data-block="visitors-today"
-    data-source="{{ site.data_url }}/{{ data_prefix }}/visitors-today.json"
+    id="users-30-days"
+    data-block="users-30-days"
+    data-source="{{ site.data_url }}/{{ data_prefix }}/total-users-30-days.json"
     data-refresh="15"
   >
-    <h2 id="current_visitors" class="data">...</h2>
+    <h2 id="visitors-30-days" class="data">...</h2>
     <div style="text-align: center" class="chart_subtitle">
-      people have visited {{ the }}{{ entity }} website{{ plural }} today
+      people have visited {{ the }}{{ entity }} website{{ plural }} in the past 30 days
     </div>
   </section>
 
   <section class="section_headline visits_today">
-    <h3>Visits Today</h3>
+    <h3>Visits Over the Past 30 Days</h3>
     <h4>Eastern Time</h4>
   </section>
   <section
     id="time_series"
-    data-block="visitors-hourly"
-    data-source="{{ site.data_url }}/{{ data_prefix }}/visitors-hourly.json"
+    data-block="users-30-days-series"
+    data-source="{{ site.data_url }}/{{ data_prefix }}/total-users-30-days.json"
     data-refresh="15"
   >
     <svg class="data time-series"></svg>
@@ -159,7 +159,7 @@ plural = "" %} {% assign the = "the " %} {% endif %}
     <!-- see: http://heydonworks.com/practical_aria_examples/ -->
     <h3>Top <span id="top_table_type">Pages</span></h3>
     <ul class="pills" role="tablist">
-      <li>
+      <!-- <li>
         <a
           role="tab"
           data-type="Pages"
@@ -168,10 +168,11 @@ plural = "" %} {% assign the = "the " %} {% endif %}
           class="site-nav"
           >Today</a
         >
-      </li>
+      </li> -->
       <li>
         <a
           role="tab"
+          aria-selected="true"
           data-type="Domains"
           href="#top-pages-7-days"
           class="site-nav"
@@ -189,7 +190,7 @@ plural = "" %} {% assign the = "the " %} {% endif %}
       </li>
     </ul>
 
-    <figure
+    <!-- <figure
       class="top-pages"
       id="top-pages-today"
       role="tabpanel"
@@ -204,7 +205,7 @@ plural = "" %} {% assign the = "the " %} {% endif %}
         >
       </h5>
       <div class="data bar-chart"></div>
-    </figure>
+    </figure> -->
 
     <figure
       class="top-pages"

--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -338,6 +338,14 @@ section {
       font-size: 6em;
     }
   }
+  #visitors-30-days {
+    font-size: 6em;
+    margin: 0;
+    text-align: center;
+    @include media($small-screen) {
+      font-size: 6em;
+    }
+  }
   h3 {
     margin: 10px 0;
   }
@@ -520,6 +528,21 @@ section {
   .axis[aria-hidden=true] {
     display: block !important; // WDS override
   }
+  .label {
+    font-size: .7rem; 
+    transform: rotate(30deg) translate(6px, -6px);
+  }
+  & rect {
+    transition: .2s ease opacity; 
+    cursor: pointer; 
+    &:hover {
+     opacity: .85; 
+      & ~ text.label {
+        font-weight: 600; 
+      }
+    }
+     
+   }
 }
 
 #current_visitors {
@@ -554,18 +577,16 @@ figure {
 }
 
 ul.pills {
-  @include clearfix;
-  @include span-columns(5 of 5);
-  display: inline-block;
 
+  display: flex; 
   border-right: 1px solid $gray;
   border-left: 1px solid $gray;
 
   li {
-    width: 33.3333%;
+    width: 100%; 
   }
 
-  &, & > li {
+  & > li {
     list-style: none;
     margin: 0;
     padding: 0;
@@ -577,7 +598,7 @@ ul.pills {
   }
 
   & > li {
-    float: left;
+    
 
     & > a {
       color: $dark-blue;

--- a/js/index.js
+++ b/js/index.js
@@ -45,6 +45,10 @@
             : formatCommas(visits);
         };
       },
+      dateFromString = function(dateString) {
+        const date = dateString.slice(0,4) + "-" + dateString.slice(4,6) + "-" + dateString.slice(6);
+        return d3.time.format.utc("%b %d")(new Date(date))
+      },
       formatVisits = formatPrefix({
         "k": ["k", 1], // thousands
         "M": ["m", 1], // millions
@@ -124,7 +128,42 @@
           document.querySelector(".section_headline.visits_today").style.display = "none";
         }
       }),
+    "users-30-days": renderBlock().
+      transform((data) => {
+        
+        const total = data.data.reduce((acc, curr) => acc += curr.totalUsers, 0); 
 
+        document.querySelector("#visitors-30-days").innerText = formatCommas(total);
+      }),
+    "users-30-days-series": renderBlock().
+      transform((data) => {
+        return data.data.map(d => ({ 
+         "date": dateFromString(d.date),
+         "totalUsers": +d.totalUsers
+        })).sort((a, b) => a.date > b.date ? 1 : -1);
+      })
+      .render((svg, data) => {
+        console.log(data)
+        let days = data; 
+        let y = (d) => d.totalUsers; 
+        let series = timeSeries()
+          .series([days])
+          .y(y)
+          .label(function(d) {
+            return d.date
+          })
+          .title(function(d) {
+            return `${d.totalUsers.toLocaleString()} total visitors on ${d.date}`
+          });
+
+        series.xScale()
+          .domain(d3.range(0, days.length + 1));
+        
+        series.yScale()
+          .domain([0, d3.max(days, y)]);
+        svg.call(series)
+      })
+    ,
     "visitors-hourly": renderBlock()
       .transform(function(data) {
 


### PR DESCRIPTION
* adds block to pull data for `totalUsers` in the past 30 days
* adds bar chart visualization to show `totalUsers` over each of the past 30 days
* removes "Today" tab from right-hand menu
* updates SCSS to use flexbox instead of float, clearfix etc