### PR TITLE
remove eastern time h2 from time series

### DIFF
--- a/_includes/charts.html
+++ b/_includes/charts.html
@@ -32,7 +32,6 @@ plural = "" %} {% assign the = "the " %} {% endif %}
 
   <section class="section_headline visits_today">
     <h3>Visits Over the Past 30 Days</h3>
-    <h4>Eastern Time</h4>
   </section>
   <section
     id="time_series"


### PR DESCRIPTION
Removes "Eastern Time" `h2` from top right hand side of time series, since the visualization now has days on the x axis and not hours